### PR TITLE
Add concurrent collection extensions

### DIFF
--- a/Sources/SwiftUtils/Collection.swift
+++ b/Sources/SwiftUtils/Collection.swift
@@ -1,0 +1,50 @@
+extension Collection where Element: Sendable {
+    public func concurrentMap<T: Sendable>(
+        _ transform: @Sendable @escaping (Element) async throws -> T
+    ) async rethrows -> [T] {
+        try await withThrowingTaskGroup(of: (Int, T).self) { group in
+            for (index, element) in self.enumerated() {
+                group.addTask {
+                    (index, try await transform(element))
+                }
+            }
+
+            var results = Array<T?>(repeating: nil, count: self.count)
+            for try await (index, value) in group {
+                results[index] = value
+            }
+            return results.compactMap { $0 }
+        }
+    }
+
+    public func concurrentForEach(
+        _ body: @Sendable @escaping (Element) async throws -> Void
+    ) async rethrows {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for element in self {
+                group.addTask {
+                    try await body(element)
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    public func concurrentCompactMap<T: Sendable>(
+        _ transform: @Sendable @escaping (Element) async throws -> T?
+    ) async rethrows -> [T] {
+        try await withThrowingTaskGroup(of: (Int, T?).self) { group in
+            for (index, element) in self.enumerated() {
+                group.addTask {
+                    (index, try await transform(element))
+                }
+            }
+
+            var results = Array<T?>(repeating: nil, count: self.count)
+            for try await (index, value) in group {
+                results[index] = value
+            }
+            return results.compactMap { $0 }
+        }
+    }
+}

--- a/Tests/SwiftUtilsTests/Tests.Collection.swift
+++ b/Tests/SwiftUtilsTests/Tests.Collection.swift
@@ -1,0 +1,35 @@
+import Testing
+import SwiftUtils
+
+extension Tests {
+    @Suite("Collection")
+    struct Collection {
+        @Test func testConcurrentMap() async throws {
+            let input = [1, 2, 3]
+            let result = await input.concurrentMap { i in i * 2 }
+            #expect(result == [2, 4, 6])
+        }
+
+        @Test func testConcurrentForEach() async throws {
+            let input = [1, 2, 3]
+            actor Box {
+                var values = [Int]()
+                func add(_ value: Int) {
+                    values.append(value)
+                }
+            }
+            let box = Box()
+            await input.concurrentForEach { element in await box.add(element * 2) }
+            let result = await box.values.sorted()
+            #expect(result == [2, 4, 6])
+        }
+
+        @Test func testConcurrentCompactMap() async throws {
+            let input = [1, 2, 3, 4]
+            let result = await input.concurrentCompactMap { value in
+                value.isMultiple(of: 2) ? value : nil
+            }
+            #expect(result == [2, 4])
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `concurrentMap`, `concurrentForEach`, and `concurrentCompactMap`
- test concurrent collection utilities

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68400c6e78a4832caf575bbf08ed558a