### PR TITLE
Fix asyncMap awaiting logic

### DIFF
--- a/Sources/SwiftUtils/Sequence.swift
+++ b/Sources/SwiftUtils/Sequence.swift
@@ -5,7 +5,8 @@ extension Sequence {
         var values = [T]()
 
         for element in self {
-            try await values.append(transform(element))
+            let transformed = try await transform(element)
+            values.append(transformed)
         }
 
         return values


### PR DESCRIPTION
## Summary
- correct awaiting of the async transform in `Sequence.asyncMap`

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_684009e13458832c9fb1ac5af476e3fb